### PR TITLE
add valid license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "character encoding utilities",
   "tags": [ "utf8", "binary", "byte", "string" ],
   "version": "0.0.1",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/pvorb/node-charenc.git"


### PR DESCRIPTION
Hi there.

A good package.json should contain a license field in SPDX format (according to npm specs: https://docs.npmjs.com/files/package.json#license).
